### PR TITLE
Fix leadership people links

### DIFF
--- a/about/our-team/index.md
+++ b/about/our-team/index.md
@@ -13,11 +13,6 @@ The **Civil Service LGBT+ Network** is led by a small team of volunteers. These 
 {% for volunteer in site.data.team %}{% if volunteer.Team == "Leadership" %}
 | {% if volunteer.Position %}{% if volunteer.Link %}[**{{ volunteer.Position }}**]({{ site.url | append: site.baseurl | append: volunteer.Link }}){% else %}**{{ volunteer.Position }}**{% endif %}{% endif %} | {% if volunteer.Email %}[{{ volunteer.Name }}]({{ volunteer.Email }}){% else %}{{ volunteer.Name }}{% endif %} |{% endif %}{% endfor %}
 
-## Communications team
-
-{% for volunteer in site.data.team %}{% if volunteer.Team == "Communications" %}
-| {% if volunteer.Position %}{% if volunteer.Link %}[**{{ volunteer.Position }}**]({{ site.url | append: site.baseurl | append: volunteer.Link }}){% else %}**{{ volunteer.Position }}**{% endif %}{% endif %} | {% if volunteer.Email %}[{{ volunteer.Name }}]({{ volunteer.Email }}){% else %}{{ volunteer.Name }}{% endif %} |{% endif %}{% endfor %}
-
 ## Local organisers
 
 Our local organisers help us deliver work in places near you. This includes our events, campaigns and social activities.

--- a/about/our-team/index.md
+++ b/about/our-team/index.md
@@ -11,18 +11,18 @@ The **Civil Service LGBT+ Network** is led by a small team of volunteers. These 
 ## Leadership team
 
 {% for volunteer in site.data.team %}{% if volunteer.Team == "Leadership" %}
-| {% if volunteer.Position %}{% if volunteer.Link %}[**{{ volunteer.Position }}**]({{ site.url | append: site.baseurl | append: volunteer.Link }}){% else %}**{{ volunteer.Position }}**{% endif %}{% endif %} | {% if volunteer.Email %}[{{ volunteer.Name }}]({{ volunteer.Email }}){% else %}{{ volunteer.Name }}{% endif %} |{% endif %}{% endfor %}
+| {% if volunteer.Position %}{% if volunteer.Link %}[**{{ volunteer.Position }}**]({{ site.url | append: site.baseurl | append: volunteer.Link }}){% else %}**{{ volunteer.Position }}**{% endif %}{% endif %} | {% if volunteer.Email %}{{ volunteer.Name }}{% else %}{{ volunteer.Name }}{% endif %} |{% endif %}{% endfor %}
 
 ## Local organisers
 
 Our local organisers help us deliver work in places near you. This includes our events, campaigns and social activities.
 
 {% for volunteer in site.data.team %}{% if volunteer.Team == "Local organisers" %}
-| {% if volunteer.Position %}{% if volunteer.Link %}[**{{ volunteer.Position }}**]({{ site.url | append: site.baseurl | append: volunteer.Link }}){% else %}**{{ volunteer.Position }}**{% endif %}{% endif %} | {% if volunteer.Email %}[{{ volunteer.Name }}]({{ volunteer.Email }}){% else %}{{ volunteer.Name }}{% endif %} |{% endif %}{% endfor %}
+| {% if volunteer.Position %}{% if volunteer.Link %}[**{{ volunteer.Position }}**]({{ site.url | append: site.baseurl | append: volunteer.Link }}){% else %}**{{ volunteer.Position }}**{% endif %}{% endif %} | {% if volunteer.Email %}{{ volunteer.Name }}{% else %}{{ volunteer.Name }}{% endif %} |{% endif %}{% endfor %}
 
 ## Project teams
 
 Our project leads help us to deliver the activities in our business plan. If you want to get involved, [send us an email](mailto:info@civilservice.lgbt).
 
 {% for volunteer in site.data.team %}{% if volunteer.Team == "Projects" %}
-| {% if volunteer.Position %}{% if volunteer.Link %}[**{{ volunteer.Position }}**]({{ site.url | append: site.baseurl | append: volunteer.Link }}){% else %}**{{ volunteer.Position }}**{% endif %}{% endif %} | {% if volunteer.Email %}[{{ volunteer.Name }}]({{ volunteer.Email }}){% else %}{{ volunteer.Name }}{% endif %} |{% endif %}{% endfor %}
+| {% if volunteer.Position %}{% if volunteer.Link %}[**{{ volunteer.Position }}**]({{ site.url | append: site.baseurl | append: volunteer.Link }}){% else %}**{{ volunteer.Position }}**{% endif %}{% endif %} | {% if volunteer.Email %}{{ volunteer.Name }}{% else %}{{ volunteer.Name }}{% endif %} |{% endif %}{% endfor %}


### PR DESCRIPTION
This PR:
- Removes the unused "Communications Team" section
- Removes links on people's names that are broken