### PR TITLE
Add domain argument to startGA

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -112,6 +112,7 @@ github-handle:  "civilservicelgbt"
 # Google settings
 google-site-verification: "RA-YBjxyRYVSuSFAYLKkufs6gjme6kMcihoB2KgKrTA"
 google-analytics: "UA-47423042-2" # GA ID code
+google-analytics-domain: "www.civilservice.lgbt"
 
 # Mailchimp
 unsubscribe-form: "https://us17.admin.mailchimp.com/lists/designer/?id=118945"

--- a/_includes/cookies/cookie-consent.html
+++ b/_includes/cookies/cookie-consent.html
@@ -24,7 +24,7 @@
 
 <script>
 if (getCookie("cookie-policy") == "true") {
-  startGA("{{ site.google-analytics }}");
+  startGA("{{ site.google-analytics }}", "{{ site.google-analytics-domain }}");
 } else if (getCookie("cookie-policy") == "false") {
   stopGA("{{ site.google-analytics }}");
 } else {

--- a/assets/scripts/scripts.js
+++ b/assets/scripts/scripts.js
@@ -48,12 +48,14 @@ function gtag() {
   dataLayer.push(arguments);
 }
 
-function startGA(trackingId){
+function startGA(trackingId, domain){
   window['ga-disable-' + trackingId] = false;
   window.dataLayer = window.dataLayer || [];
   gtag("js", new Date());
 
-  gtag("config", trackingId);
+  gtag("config", trackingId, {
+  'cookie_domain': domain
+});
 }
 
 function stopGA(trackingId) {


### PR DESCRIPTION
GA will automatically set cookies to the highest domain level. i.e. civilservice.lgbt. This prevents GA cookies from being delete when viewing the site from www.civilservice.lgbt. To fix this we explicit state that GA sets cookies at the "www" subdomain level.