### PR TITLE
Add domain argument to deleteCookies

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -112,7 +112,7 @@ github-handle:  "civilservicelgbt"
 # Google settings
 google-site-verification: "RA-YBjxyRYVSuSFAYLKkufs6gjme6kMcihoB2KgKrTA"
 google-analytics: "UA-47423042-2" # GA ID code
-google-analytics-domain: "www.civilservice.lgbt"
+google-analytics-domain: ".www.civilservice.lgbt"
 
 # Mailchimp
 unsubscribe-form: "https://us17.admin.mailchimp.com/lists/designer/?id=118945"

--- a/_includes/cookies/cookie-consent.html
+++ b/_includes/cookies/cookie-consent.html
@@ -26,9 +26,9 @@
 if (getCookie("cookie-policy") == "true") {
   startGA("{{ site.google-analytics }}", "{{ site.google-analytics-domain }}");
 } else if (getCookie("cookie-policy") == "false") {
-  stopGA("{{ site.google-analytics }}");
+  stopGA("{{ site.google-analytics }}", "{{ site.google-analytics-domain }}");
 } else {
-  stopGA("{{ site.google-analytics }}");
+  stopGA("{{ site.google-analytics }}", "{{ site.google-analytics-domain }}");
   document.getElementById("cookie-notice").style.display = "block";
   document.getElementById("cookie-choice").style.display = "block";
   document.getElementById("cookie-choice-confirmation").style.display = "none";

--- a/_includes/cookies/measurement-cookies-change.html
+++ b/_includes/cookies/measurement-cookies-change.html
@@ -36,6 +36,6 @@ document
   .getElementById("disable-measurement-cookies")
   .addEventListener("click", function () {
     setCookie("cookie-policy", "false", 31);
-    stopGA("{{ site.google-analytics }}");
+    stopGA("{{ site.google-analytics }}", "{{ site.google-analytics-domain }}");
   });
 </script>

--- a/assets/scripts/scripts.js
+++ b/assets/scripts/scripts.js
@@ -17,29 +17,33 @@ function getCookie(name) {
   }
 }
 
-function setCookie(name, value, days) {
+function setCookie(name, value, days, domain) {
   var expires = "";
   if (days) {
     var date = new Date();
     date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000);
     expires = "; expires=" + date.toUTCString();
   }
-  document.cookie = name + "=" + value + expires + "; path=/";
+  var cookieString = name + "=" + value + expires + "; path=/;";
+  if (domain) {
+    cookieString = cookieString + " Domain=" + domain + ";";
+  }
+  document.cookie = cookieString;
 }
 
-function removeCookie(name) {
-  setCookie(name, "", -1);
+function removeCookie(name, domain) {
+  setCookie(name, "", -1, domain);
 }
 
 
-function deleteCookies(prefix) {
+function deleteCookies(prefix, domain) {
   var cookies = document.cookie.split("; ");
   for (var i = 0; i < cookies.length; i++) {
     var parts = cookies[i].split('=');
     var key = parts[0];
 
     if (key.indexOf(prefix) === 0) {
-      removeCookie(key);
+      removeCookie(key, domain);
     }
   }
 }
@@ -58,7 +62,7 @@ function startGA(trackingId, domain){
 });
 }
 
-function stopGA(trackingId) {
+function stopGA(trackingId, domain) {
   window['ga-disable-' + trackingId] = true;
-  deleteCookies("_g");
+  deleteCookies("_g", domain);
 }


### PR DESCRIPTION
This fixes an issue where we were unable to delete GA cookies because of they were set on a different domain. GA cookies are set to match all subdomains i.e. ".www.civilservice.lgbt", however we were only to delete cookies for the exact domain "www.civilservice.lgbt". This adds a domain argument to be able to specify the domain in which to set and delete cookies from.