### PR TITLE
Refactor content on the Our Team page

### DIFF
--- a/about/our-team/index.md
+++ b/about/our-team/index.md
@@ -1,14 +1,14 @@
 ---
 layout: page
 title: Our team
-excerpt: 'We are a volunteer-led network, made up of members from across the UK.'
+excerpt: 'We are a volunteer-led network, made up of members from across the UK. These volunteers give up their spare time to support LGBT+ civil servants.'
 permalink: /about/our-team/
 published: true
 ---
 
-The **Civil Service LGBT+ Network** is led by a small team of volunteers. These volunteers give up their spare time to support LGBT+ civil servants.
-
 ## Leadership team
+
+The Civil Service LGBT+ Network is led by a small team of volunteers.
 
 {% for volunteer in site.data.team %}{% if volunteer.Team == "Leadership" %}
 | {% if volunteer.Position %}{% if volunteer.Link %}[**{{ volunteer.Position }}**]({{ site.url | append: site.baseurl | append: volunteer.Link }}){% else %}**{{ volunteer.Position }}**{% endif %}{% endif %} | {% if volunteer.Email %}{{ volunteer.Name }}{% else %}{{ volunteer.Name }}{% endif %} |{% endif %}{% endfor %}

--- a/about/our-team/index.md
+++ b/about/our-team/index.md
@@ -11,18 +11,18 @@ published: true
 The Civil Service LGBT+ Network is led by a small team of volunteers.
 
 {% for volunteer in site.data.team %}{% if volunteer.Team == "Leadership" %}
-| {% if volunteer.Position %}{% if volunteer.Link %}[**{{ volunteer.Position }}**]({{ site.url | append: site.baseurl | append: volunteer.Link }}){% else %}**{{ volunteer.Position }}**{% endif %}{% endif %} | {% if volunteer.Email %}{{ volunteer.Name }}{% else %}{{ volunteer.Name }}{% endif %} |{% endif %}{% endfor %}
+| {% if volunteer.Position %}{% if volunteer.Link %}[**{{ volunteer.Position }}**]({{ site.url | append: site.baseurl | append: volunteer.Link }}){% else %}**{{ volunteer.Position }}**{% endif %}{% endif %} | {% if volunteer.Email %}[{{ volunteer.Name }}](mailto:{{ volunteer.Email }}){% else %}{{ volunteer.Name }}{% endif %} |{% endif %}{% endfor %}
 
 ## Local organisers
 
 Our local organisers help us deliver work in places near you. This includes our events, campaigns and social activities.
 
 {% for volunteer in site.data.team %}{% if volunteer.Team == "Local organisers" %}
-| {% if volunteer.Position %}{% if volunteer.Link %}[**{{ volunteer.Position }}**]({{ site.url | append: site.baseurl | append: volunteer.Link }}){% else %}**{{ volunteer.Position }}**{% endif %}{% endif %} | {% if volunteer.Email %}{{ volunteer.Name }}{% else %}{{ volunteer.Name }}{% endif %} |{% endif %}{% endfor %}
+| {% if volunteer.Position %}{% if volunteer.Link %}[**{{ volunteer.Position }}**]({{ site.url | append: site.baseurl | append: volunteer.Link }}){% else %}**{{ volunteer.Position }}**{% endif %}{% endif %} | {% if volunteer.Email %}[{{ volunteer.Name }}](mailto:{{ volunteer.Email }}){% else %}{{ volunteer.Name }}{% endif %} |{% endif %}{% endfor %}
 
 ## Project teams
 
 Our project leads help us to deliver the activities in our business plan. If you want to get involved, [send us an email](mailto:info@civilservice.lgbt).
 
 {% for volunteer in site.data.team %}{% if volunteer.Team == "Projects" %}
-| {% if volunteer.Position %}{% if volunteer.Link %}[**{{ volunteer.Position }}**]({{ site.url | append: site.baseurl | append: volunteer.Link }}){% else %}**{{ volunteer.Position }}**{% endif %}{% endif %} | {% if volunteer.Email %}{{ volunteer.Name }}{% else %}{{ volunteer.Name }}{% endif %} |{% endif %}{% endfor %}
+| {% if volunteer.Position %}{% if volunteer.Link %}[**{{ volunteer.Position }}**]({{ site.url | append: site.baseurl | append: volunteer.Link }}){% else %}**{{ volunteer.Position }}**{% endif %}{% endif %} | {% if volunteer.Email %}[{{ volunteer.Name }}](mailto:{{ volunteer.Email }}){% else %}{{ volunteer.Name }}{% endif %} |{% endif %}{% endfor %}


### PR DESCRIPTION
This PR removes the small paragraph before the teams. Adds more context to the leadership and expands the excerpt.

![image](https://user-images.githubusercontent.com/11051676/81743606-ddc7fe00-9499-11ea-9831-0623b7794b3b.png)
