### PR TITLE
Refactor the About and Contact Us page

### DIFF
--- a/about/contact-us.md
+++ b/about/contact-us.md
@@ -10,9 +10,9 @@ permalink: /about/contact-us/
 
 You can contact us via:
 
-- **Email:** [info@civilservice.lgbt](mailto:info@civilservice.lgbt)
-- **Facebook:** Like **[our Facebook Page]({{ site.facebook-url }})**
-- **Twitter:** Follow us [@cslgbt]({{ site.twitter-url}})
+- Email at [info@civilservice.lgbt](mailto:info@civilservice.lgbt)
+- Facebook at [civilservicelgbt]({{ site.facebook-url }})
+- Twitter at [@cslgbt]({{ site.twitter-url}})
 
 We aim to reply to most correspondence within a week, but please remember we are volunteers, doing this on top of our day jobs, so it sometimes takes longer for us to respond.
 

--- a/about/contact-us.md
+++ b/about/contact-us.md
@@ -6,8 +6,6 @@ excerpt: "Our contact details, in case you want to get in touch."
 permalink: /about/contact-us/
 ---
 
-## Contact us
-
 You can contact us via:
 
 - Email at [info@civilservice.lgbt](mailto:info@civilservice.lgbt)
@@ -18,12 +16,18 @@ We aim to reply to most correspondence within a week, but please remember we are
 
 ### Ask us to share your content
 
-If you have written a blog post, are holding an event or have written a publication, and you want to share it with LGBT+ civil servants, then complete one of the forms below and we’ll add it to our website[^1].
+We are happy to publish content that you want to share with LGBT+ civil servants. This includes:
 
-- [Submit a blog post or news article](https://docs.google.com/forms/d/e/1FAIpQLSeXUakASP-92eGAHFV-1S7f8vFLFyIbhjXan2XvDYFeaJ56Gw/viewform)
-- [Submit an event](https://docs.google.com/forms/d/e/1FAIpQLSc44JVkqzJarxljvRksuqjXQnqt0k4cb9Ix0taCqc7ianHDew/viewform)
-- [Submit a publication](https://docs.google.com/forms/d/e/1FAIpQLScYK-0IPeRS_mZD7bQg5tyZ_-otkQ9w9m-SbtEeFbGiD_nsMg/viewform)
+- blog posts
+- news articles
+- events
+- publications
 
-If you want to consult with our members on a particular issue relevant to LGBT+ civil servants, then [complete this form](https://docs.google.com/forms/d/e/1FAIpQLSe_y6NwmrLf2sKLSmQXGUdfvjlSNoziqtde7TJCxNIcnsmXDg/viewform).
+Send us an email at [info@civilservice.lgbt](mailto:info@civilservice.lgbt) and we’ll add it to our website.
 
-[^1]: Please note, due to the voluntary nature of our network, and the Civil Service Code, we can’t accept all requests to publish content. In general, if your content is relevant to LGBT+ civil servants as civil servants, and adheres to the 4 Civil Service principles of ‘honesty’, ‘integrity’, ‘objectivity’, and ‘impartiality’, we will be happy to publish your content.
+We can’t accept all requests to publish content due to the voluntary nature of our network. Content should be relevant to LGBT+ civil servants as civil servants and adhere to the [Civil Service Code](https://www.gov.uk/government/publications/civil-service-code/the-civil-service-code). 
+
+### Hold a consultation
+
+If you want to consult with our members on a particular issue relevant to LGBT+ civil servants, send us an email at [info@civilservice.lgbt](mailto:info@civilservice.lgbt).
+

--- a/about/index.md
+++ b/about/index.md
@@ -14,10 +14,10 @@ Our mission is to support and challenge the Civil Service to become the most inc
 2. building a national community of LGBT+ civil servants
 3. representing the needs of LGBT+ staff to central Civil Service policy teams and the Senior Civil Service
 
-Read our **[constitution](/about/constitution)** and our **[mission statement](/about/mission-statement)**
+Read our **[constitution](/about/constitution)** and our **[mission statement](/about/mission-statement)**.
 
 ## Our team
 
 We are a volunteer-led network based all over the UK. Our volunteers develop policy, organise and deliver social, networking and learning events, and promote diversity and inclusion of LGBT+ staff. 
 
-Learn more about **[our team](/about/our-team/)**
+Learn more about **[our team](/about/our-team/)**.

--- a/about/index.md
+++ b/about/index.md
@@ -6,8 +6,6 @@ excerpt: "The Civil Service LGBT+ Network helps to create a more diverse, inclus
 permalink: /about/
 ---
 
-We're the Civil Service LGBT+ Network. We represent the interests of an estimated 20,000 lesbian, gay, bisexual and transgender people working in the UK Civil Service. 
-
 ## Our mission
 
 Our mission is to support and challenge the Civil Service to become the most inclusive employer for LGBT+ people in the country. We do that by: 
@@ -16,32 +14,10 @@ Our mission is to support and challenge the Civil Service to become the most inc
 2. building a national community of LGBT+ civil servants
 3. representing the needs of LGBT+ staff to central Civil Service policy teams and the Senior Civil Service
 
-> Read our **[constitution](/about/constitution)** and our **[mission statement](/about/mission-statement)**
+Read our **[constitution](/about/constitution)** and our **[mission statement](/about/mission-statement)**
 
 ## Our team
 
 We are a volunteer-led network based all over the UK. Our volunteers develop policy, organise and deliver social, networking and learning events, and promote diversity and inclusion of LGBT+ staff. 
 
-> Learn more about **[our team](/about/our-team/)**
-
-## Contact us
-
-You can contact us via:
-
-- **Email:** [info@civilservice.lgbt](mailto:info@civilservice.lgbt)
-- **Facebook:** Like **[our Facebook Page]({{ site.facebook-url }})**
-- **Twitter:** Follow us [@cslgbt]({{ site.twitter-url}})
-
-We aim to reply to most correspondence within a week, but please remember we are volunteers, doing this on top of our day jobs, so it sometimes takes longer for us to respond.
-
-### Ask us to share your content
-
-If you have written a blog post, are holding an event or have written a publication, and you want to share it with LGBT+ civil servants, then complete one of the forms below and we’ll add it to our website[^1].
-
-- [Submit a blog post or news article](https://docs.google.com/forms/d/e/1FAIpQLSeXUakASP-92eGAHFV-1S7f8vFLFyIbhjXan2XvDYFeaJ56Gw/viewform)
-- [Submit an event](https://docs.google.com/forms/d/e/1FAIpQLSc44JVkqzJarxljvRksuqjXQnqt0k4cb9Ix0taCqc7ianHDew/viewform)
-- [Submit a publication](https://docs.google.com/forms/d/e/1FAIpQLScYK-0IPeRS_mZD7bQg5tyZ_-otkQ9w9m-SbtEeFbGiD_nsMg/viewform)
-
-If you want to consult with our members on a particular issue relevant to LGBT+ civil servants, then [complete this form](https://docs.google.com/forms/d/e/1FAIpQLSe_y6NwmrLf2sKLSmQXGUdfvjlSNoziqtde7TJCxNIcnsmXDg/viewform).
-
-[^1]: Please note, due to the voluntary nature of our network, and the Civil Service Code, we can’t accept all requests to publish content. In general, if your content is relevant to LGBT+ civil servants as civil servants, and adheres to the 4 Civil Service principles of ‘honesty’, ‘integrity’, ‘objectivity’, and ‘impartiality’, we will be happy to publish your content.
+Learn more about **[our team](/about/our-team/)**


### PR DESCRIPTION
This PR includes the following changes:
- Removal of the Contact Us section from the About page
- Simplifying of the content and styling for both pages
- Removal of the Google Forms as methods to submit content to be shared