### PR TITLE
Adds 'reversed' for displaying publicatiosn

### DIFF
--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -102,7 +102,7 @@ layout: skeleton
 					{% assign today-date = 'now' | date: '%Y' %}
 					{% assign publications = site.publications | where: 'category', page.category %}
 
-					{% for post in publications %}
+					{% for post in publications reversed %}
 
 						<li>
 							<article>


### PR DESCRIPTION
Publications were displaying oldest first, unlike updates, on topic pages. This adds 'reversed' so newer publications display first.