### PR TITLE
Topic pages auto hide

### DIFF
--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -79,14 +79,22 @@ layout: skeleton
     {% endif %}
       
     <div id="page-content">
+
+      <!-- Blog posts / news updates --> 
+
+      {% assign today-date = 'now' | date: '%Y' %}
+      {% assign posts = site.posts | where: 'category', page.category %}
+      {% assign not-empty = 0 %}
+
+      {% for post in posts %}
+      {% assign not-empty = not-empty | plus: 1 %}
+      {% endfor %}
+
+      {% if not-empty != 0 %}
+
       <section id="topic-section">
         <h2 class="section-title">Updates</h2>
-        <ul>
-          {% assign today-date = 'now' | date: '%Y' %}
-          {% assign posts = site.posts | where: 'category', page.category %}
-
-          {% assign not-empty = 0 %}
-
+        <ul>     
           {% for post in posts %}
             <li>
               <article>
@@ -94,23 +102,30 @@ layout: skeleton
                 <p class="post-metadata"><time datetime="{{ post.date | date: '%Y-%m-%d %H:%M' }}">{{ post.date  | date:'%-d %B %Y' }}</time></p>
               </article>
             </li>		
-            {% assign not-empty = not-empty | plus: 1 %}
           {% endfor %}
-
-          {% if not-empty == 0 %}
-            <li><article><h2>No updates</h2></article></li>
-          {% endif %}
         </ul>
       </section>
+
+      {% endif %}
+
+      <!-- Events --> 
+
+      {% assign today-date = 'now' | date: '%Y-%m-%d' %}
+      {% assign events = site.events | where: 'category', page.category %}
+      {% assign not-empty = 0 %}
+
+      {% for post in events %}
+      {% assign date = post.event-date | date: '%Y-%m-%d' %}
+      {% if today-date <= date %}
+      {% assign not-empty = not-empty | plus: 1 %}		
+      {% endif %}
+      {% endfor %}
+
+      {% if not-empty != 0 %}
 
       <section id="topic-section">
         <h2 class="section-title">Events</h2>
         <ul>
-        {% assign today-date = 'now' | date: '%Y-%m-%d' %}
-        {% assign events = site.events | where: 'category', page.category %}
-
-        {% assign not-empty = 0 %}
-
         {% for post in events %}
           {% assign date = post.event-date | date: '%Y-%m-%d' %}
           {% if today-date <= date %}
@@ -120,24 +135,28 @@ layout: skeleton
                 <p class="post-metadata"><time datetime="{{ post.event-date | date: '%Y-%m-%d %H:%M' }}">{{ post.event-date  | date:'%-d %B %Y at %H:%M' }}</time></p>
               </article>
             </li>		
-          {% assign not-empty = not-empty | plus: 1 %}
           {% endif %}
         {% endfor %}
-
-        {% if not-empty == 0 %}
-          <li><article><h2>No upcoming events</h2></article></li>
-        {% endif %}
         </ul>
       </section>
+
+      {% endif %}
+
+      <!-- Publications --> 
+
+      {% assign today-date = 'now' | date: '%Y' %}
+      {% assign publications = site.publications | where: 'category', page.category %}
+      {% assign not-empty = 0 %}
+
+      {% for post in publications reversed %}
+      {% assign not-empty = not-empty | plus: 1 %}
+      {% endfor %}
+
+      {% if not-empty != 0 %}
 
       <section id="topic-section">
         <h2 class="section-title">Publications</h2>
         <ul>
-          {% assign today-date = 'now' | date: '%Y' %}
-          {% assign publications = site.publications | where: 'category', page.category %}
-          
-          {% assign not-empty = 0 %}
-
           {% for post in publications reversed %}
             <li>
               <article>
@@ -145,14 +164,12 @@ layout: skeleton
                 <p class="post-metadata"><time datetime="{{ post.date | date: '%Y-%m-%d %H:%M' }}">{{ post.date  | date:'%-d %B %Y' }}</time></p>
               </article>
             </li>
-            {% assign not-empty = not-empty | plus: 1 %}
           {% endfor %}
-
-          {% if not-empty == 0 %}
-            <li><article><h2>No publications</h2></article></li>
-          {% endif %}
         </ul>
       </section>
+
+      {% endif %}
+
     </div>
   </main>
 </div>

--- a/_topics/pride-2019.md
+++ b/_topics/pride-2019.md
@@ -6,5 +6,6 @@ layout: topic
 category: pride-2019
 
 image: /assets/images/pages/pride.png
+published: false
 ---
 


### PR DESCRIPTION
Suggesting we make sections on the topics page auto hide if they are empty, as it looks a bit silly having empty sections (especially for events, as they remove themselves once they have passed and the site rebuilds).