### PR TITLE
Site-wide banner iterations

### DIFF
--- a/_data/global-banner.yaml
+++ b/_data/global-banner.yaml
@@ -1,4 +1,7 @@
-- show: true
-  text: "PrideON Podcast - the new podcast from the Civil Service LGBT+ Network"
-  link-text: "find out how you can listen and subscribe"
-  link: /podcast/
+- show: true #This turns the banner on and off. For example: 'true' is on, 'false' is off
+  background: cyan #Options are magenta, cyan or black
+  end-date: "2020-12-05" #date in YEAR-MONTH-DAY, example 2020-10-21
+  exclude:  #If linking to a page on the website, add the URL here. For example: /pride/
+  
+  #Use normal markdown - the text should be no more than 119 characters.
+  content: We're delighted to be shortlisted for two [Civil Service Diversity and Inclusion Awards](https://www.diversityandinclusionawards.com). Read the [full shortlist](https://www.diversityandinclusionawards.com/shortlist).

--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -1,9 +1,9 @@
 <div id="site-banner">
- <div id="banner">
+  {% for banner in site.data.global-banner %}
+ <div id="banner" class="{{ banner.background }}">
  <div class="container">
   <ul id="banner-items">
-    {% for banner in site.data.global-banner %}
-   <li>{{ banner.text }}: <a href="{{ banner.link }}" title="{{ banner.link-text }}">{{ banner.link-text }}</a></li>
+  <li>{{ banner.content | markdownify }}</li>
   {% endfor %}
   </ul>
  </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -27,8 +27,12 @@
 	</div>
 </nav>
 
+{% assign today-date = site.time | date: "%Y-%m-%d" %}
 {% for banner in site.data.global-banner %}
-{% if banner.show == true and page.url != banner.link %}
+{% assign end-date = banner.end-date | date: "%Y-%m-%d" %}
+{% if today-date < end-date %}
+{% if banner.show == true and page.url != banner.exclude %}
 {% include banner.html %}
+{% endif %}
 {% endif %}
 {% endfor %}

--- a/_layouts/skeleton.html
+++ b/_layouts/skeleton.html
@@ -2,7 +2,7 @@
 	
 	{% include head.html %}
 
-	<body class="{{ page.layout }}{% if page.preview == true %} preview{% endif %}{% for banner in site.data.global-banner %}{% if banner.show == true %} global-banner{% endif %}{% endfor %}">
+	<body class="{{ page.layout }}{% if page.preview == true %} preview{% endif %}{% for banner in site.data.global-banner %}{% assign today-date = site.time | date: "%Y-%m-%d" %}{% assign end-date = banner.end-date | date: "%Y-%m-%d" %}{% if banner.show == true and today-date < end-date %} global-banner{% endif %}{% endfor %}">
 		
 		<div class="wrapper">
 		

--- a/_manuals/2019-10-01-adding-posts-to-the-website.md
+++ b/_manuals/2019-10-01-adding-posts-to-the-website.md
@@ -179,6 +179,22 @@ Some post layouts require additional HTML mark up to be included in order to dis
 
 The templates in `_templates` already contain the necessary code. Include your post content in the appropriate place, and do not edit the wrap around code or the formatting of posts will break.
 
+## Updating the site-wide banner
+
+The site-wide banner can be used to promote events and featured news items across every page on the website.
+
+The banner can be edited from `_data/global_banner.yaml`. You must include:
+
+**show**: this either needs to be `true` (on) or `false` (off)
+
+**background**: the banner can have a `magenta`, `cyan` or `black` background
+
+**end-date**: this is the date when the banner will be automatically turned off in `YYYY-MM-DD` format
+
+**exclude**: add the slug of the page linked to in the banner, for example `/pride/`. This means the banner won't show on this page. This is only needed if the banner is linking to another page on `www.civilservice.lgbt`.
+
+**content**: this is the text in the banner. Use normal markdown. The banner content should be less than 119 characters, minus any markdown.
+
 ## Forcing the site to regenerate
 
 The website is a 'static' website, meaning that the content only updates when it is rebuilt because the content of a page has changed. In order to trigger a refresh you will need to 'push' a new or updated page to the website.

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -210,11 +210,21 @@ div#site-banner {
   padding: 0px;
   margin: 0;
 
-  div#banner {
-    background: $magenta;
-
+  div#banner {   
     padding: 0 15px;
     margin: 0;
+    
+    &.magenta {
+      background: $magenta;
+    }
+    
+    &.cyan {
+      background: $cyan;
+    }
+    
+    &.black {
+      background: $black;
+    }
 
     &::after {
       content: "";
@@ -257,8 +267,11 @@ div#site-banner {
     }
 
     li {
-      display: block;
       padding: 0px;
+    
+    p {
+      display: block;
+      padding: inherit;
       font-size: $font-size-base - 2px;
       color: $white;
       font-weight: bold;
@@ -276,19 +289,16 @@ div#site-banner {
 
       a {
         color: $white;
-        font-weight: normal;
         text-decoration: underline;
-      }
       
-      &:hover a,
-      &:focus a  {
-        -webkit-color: $light-gray;
-        color: $light-gray;
-      }
-
-      &.active a {
-        color: $cyan;
+      
+      &:hover,
+      &:focus  {
+        -webkit-color: $dark-gray;
+        color: $dark-gray;
       }
     }
+    }
+  }
   }
 }

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -294,8 +294,8 @@ div#site-banner {
       
       &:hover,
       &:focus  {
-        -webkit-color: $dark-gray;
-        color: $dark-gray;
+        -webkit-color: $light-gray;
+        color: $light-gray;
       }
     }
     }


### PR DESCRIPTION
This PR includes various banner iterations including:

- now using markdown for banner content
- extra background colour options
- end date for the banner show (pending the [creation of a GitHub action](https://stackoverflow.com/questions/24098792/how-to-force-github-pages-build/61706020#61706020) to re-build the site every night at 00:01)
- updated guidance on updating the banner
- updated banner content